### PR TITLE
Fix/ensure confirmation token kwarg is url decoded

### DIFF
--- a/blog/services/confirmation_service.py
+++ b/blog/services/confirmation_service.py
@@ -1,10 +1,10 @@
 from django.core.signing import TimestampSigner, SignatureExpired, BadSignature
 
+signer = TimestampSigner()
+
 
 class ConfirmationService:
     def attempt_token_unsign(signed_token):
-        signer = TimestampSigner()
-
         try:
             unsigned = signer.unsign_object(signed_token, max_age=172_800)
             unsigned_token = unsigned["confirmation_token"]
@@ -16,7 +16,6 @@ class ConfirmationService:
             return None
 
     def generate_signed_token(confirmable_instance):
-        signer = TimestampSigner()
         signed_token = signer.sign_object(
             {"confirmation_token": confirmable_instance.confirmation_token}
         )

--- a/blog/tests/views/subscription_views_test.py
+++ b/blog/tests/views/subscription_views_test.py
@@ -1,7 +1,6 @@
 import json
 import os
-
-from unittest import mock
+import urllib.parse
 
 from django.conf import settings
 from django.core.signing import TimestampSigner
@@ -12,9 +11,11 @@ from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
 
+from unittest import mock
+
 from blog.models import Subscription
-from blog.tests.factories import UserFactory, SubscriptionFactory
 from blog.services.challenge_service import ChallengeService
+from blog.tests.factories import UserFactory, SubscriptionFactory
 
 ok_response = HttpResponse(status=status.HTTP_200_OK)
 
@@ -181,7 +182,7 @@ class SubscriptionTests(APITestCase):
 
     def test_user_can_confirm_subscription_with_valid_token(self):
         response = self.client.put(
-            f"/subscription/confirmation/{self.signed_token}",
+            f"/subscription/confirmation/{urllib.parse.quote(self.signed_token)}",
             format="json",
         )
         response_json = json.loads(response.content)
@@ -197,7 +198,7 @@ class SubscriptionTests(APITestCase):
         self.subscription.save()
 
         response = self.client.put(
-            f"/subscription/confirmation/{self.signed_token}",
+            f"/subscription/confirmation/{urllib.parse.quote(self.signed_token)}",
             format="json",
         )
         response_json = json.loads(response.content)

--- a/blog/views/confirmation_views.py
+++ b/blog/views/confirmation_views.py
@@ -16,9 +16,8 @@ class ConfirmationView(generics.UpdateAPIView):
     permission_classes = [AllowAny]
 
     def get_object(self):
-        unsigned_token = ConfirmationService.attempt_token_unsign(
-            self.kwargs["signed_confirmation_token"]
-        )
+        url_decoded_token = self.kwargs["signed_confirmation_token"].replace("%3A", ":")
+        unsigned_token = ConfirmationService.attempt_token_unsign(url_decoded_token)
 
         return get_object_or_404(
             User,
@@ -26,9 +25,8 @@ class ConfirmationView(generics.UpdateAPIView):
         )
 
     def get_queryset(self):
-        unsigned_token = ConfirmationService.attempt_token_unsign(
-            self.kwargs["signed_confirmation_token"]
-        )
+        url_decoded_token = self.kwargs["signed_confirmation_token"].replace("%3A", ":")
+        unsigned_token = ConfirmationService.attempt_token_unsign(url_decoded_token)
 
         return get_object_or_404(
             User,

--- a/blog/views/subscription_views.py
+++ b/blog/views/subscription_views.py
@@ -22,7 +22,7 @@ class SubscriptionCreateAPIView(generics.CreateAPIView):
     serializer_class = SubscriptionSerializer
 
     def post(self, request, *args, **kwargs):
-        challenge = ChallengeImageSerializer(data={**request.data})
+        challenge = ChallengeImageSerializer(data=request.data)
 
         if not challenge.is_valid():
             return JsonResponse(
@@ -52,9 +52,8 @@ class SubscriptionConfirmationUpdateAPIView(generics.UpdateAPIView):
     permission_classes = [AllowAny]
 
     def get_object(self):
-        unsigned_token = ConfirmationService.attempt_token_unsign(
-            self.kwargs["signed_confirmation_token"]
-        )
+        url_decoded_token = self.kwargs["signed_confirmation_token"].replace("%3A", ":")
+        unsigned_token = ConfirmationService.attempt_token_unsign(url_decoded_token)
 
         return get_object_or_404(
             Subscription,
@@ -62,9 +61,8 @@ class SubscriptionConfirmationUpdateAPIView(generics.UpdateAPIView):
         )
 
     def get_queryset(self):
-        unsigned_token = ConfirmationService.attempt_token_unsign(
-            self.kwargs["signed_confirmation_token"]
-        )
+        url_decoded_token = self.kwargs["signed_confirmation_token"].replace("%3A", ":")
+        unsigned_token = ConfirmationService.attempt_token_unsign(url_decoded_token)
 
         return get_object_or_404(
             Subscription,


### PR DESCRIPTION
## What?
This patches a possible issue when sending the signed confirmation token from a client that encodes url strings. This can be an issue when receiving the encoded string because the signed token is segmented by colons ` : ` which would be encoded to `%3A` per the standard URL encoded scheme [[RFC-3986](https://www.rfc-editor.org/rfc/rfc3986#page-13)]

## Why?
Improperly decoding the signed token to identify the signature delimiters will result in an unsigning failure, thus resulting in a not found response, even for a valid token.

## How?
Because ` : ` to `%3A` is a standardized and deterministic encoding value, we will do a substring replace on the `signed_confirmation_token` kwarg in the subscription and confirmation views. We do not necessarily want to completely decode the encoded string, our signing scheme will create alphanumeric characters and ` : ` delimiters, so we should not expect other character encodings in our token. As such any other instances of character decoding could indicate token tampering and malicious query injections.

## Testing?
Unit tests have been added in `blog/tests/views/subscription_views_test.py` that will url encode the signed token before performing the confirmation request to simulate a possible client encoded url string.
