### PR TITLE
Features/adds draft posts dashboard endpoint

### DIFF
--- a/blog/serializers/post_serializer.py
+++ b/blog/serializers/post_serializer.py
@@ -25,6 +25,7 @@ class PostSerializer(serializers.ModelSerializer):
             "cover_image_url",
             "created_on",
             "description",
+            "draft",
             "excerpt",
             "featured",
             "last_modified",
@@ -33,14 +34,6 @@ class PostSerializer(serializers.ModelSerializer):
             "title",
             "user",
         ]
-
-    def __init__(self, *args, **kwargs):
-        super(PostSerializer, self).__init__(*args, **kwargs)
-        request = self.context.get("request")
-        if request and request.method == "POST":
-            self.Meta.depth = 0
-        else:
-            self.Meta.depth = 1
 
     def get_profile(self, post):
         return post.user.profile
@@ -67,7 +60,7 @@ class CreatePostSerializer(serializers.ModelSerializer):
         ]
 
     def validate(self, data):
-        self.slug = slugify(data["title"])
+        self.slug = slugify(data.get("title"))
 
         super().validate(data)
 

--- a/blog/tests/views/post_views_test.py
+++ b/blog/tests/views/post_views_test.py
@@ -127,7 +127,7 @@ class AuthenticatedPostTests(APITestCase):
     def test_authenticated_user_can_list_drafts(self):
         category = CategoryFactory(user=self.user)
         post = PostFactory.create(user=self.user, categories=[category], draft=True)
-        response = self.client.get(f"/dashboard/post_drafts", format="json")
+        response = self.client.get("/dashboard/post_drafts", format="json")
         response_json = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/blog/tests/views/post_views_test.py
+++ b/blog/tests/views/post_views_test.py
@@ -124,6 +124,15 @@ class AuthenticatedPostTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response_json[0]["title"], post.title)
 
+    def test_authenticated_user_can_list_drafts(self):
+        category = CategoryFactory(user=self.user)
+        post = PostFactory.create(user=self.user, categories=[category], draft=True)
+        response = self.client.get(f"/dashboard/post_drafts", format="json")
+        response_json = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_json[0]["title"], post.title)
+
 
 class PostTests(APITestCase):
     def test_user_can_list_posts(self):

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -133,6 +133,11 @@ urlpatterns = [
         name="dashboard_posts_path",
     ),
     path(
+        "dashboard/post_drafts",
+        blog_views.DashboardPostDraftListAPIView.as_view(),
+        name="dashboard_draft_posts_path",
+    ),
+    path(
         "dashboard/categories/<category_slug>/posts",
         blog_views.DashboardCategoryPostListAPIView.as_view(),
         name="dashboard_category_posts_path",

--- a/blog/views/__init__.py
+++ b/blog/views/__init__.py
@@ -35,6 +35,7 @@ from .authenticated.post_views import (
     DashboardPostRetrieveUpdateDestroyAPIView as DashboardPostRetrieveUpdateDestroyAPIView,
     PostLikeCreateAPIView as PostLikeCreateAPIView,
     DashboardCategoryPostListAPIView as DashboardCategoryPostListAPIView,
+    DashboardPostDraftListAPIView as DashboardPostDraftListAPIView,
 )
 
 from .authenticated.project_views import (

--- a/blog/views/authenticated/post_views.py
+++ b/blog/views/authenticated/post_views.py
@@ -33,6 +33,15 @@ class DashboardPostListCreateAPIView(generics.ListCreateAPIView):
 
 
 @method_decorator(require_GET, name="get")
+class DashboardPostDraftListAPIView(generics.ListAPIView):
+    serializer_class = PostSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return Post.objects.filter(user=self.request.user, draft=True).order_by("-id")
+
+
+@method_decorator(require_GET, name="get")
 class DashboardCategoryPostListAPIView(generics.ListAPIView):
     serializer_class = PostSerializer
     permission_classes = [IsAuthenticated]

--- a/blog/views/authenticated/post_views.py
+++ b/blog/views/authenticated/post_views.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
@@ -72,7 +74,13 @@ class DashboardPostRetrieveUpdateDestroyAPIView(generics.RetrieveUpdateDestroyAP
         post = self.get_queryset()
         partial = request.method == "PATCH"
         serializer = CreatePostSerializer(
-            post, data={**request.data, "user": self.request.user.id}, partial=partial
+            post,
+            data={
+                **request.data,
+                "user": self.request.user.id,
+                "last_modified": datetime.utcnow(),
+            },
+            partial=partial,
         )
 
         if serializer.is_valid():


### PR DESCRIPTION
## What?
This adds an endpoint for authenticated users to be able to list their unpublished posts. It also sets the `last_modified` to the present time on a post update action.

## Why?
Saving posts as drafts is an important feature for users to be able to review and proofread their post before making it live

## How?
The standard pattern for adding a class based view in DRF.

## Testing?
Unit tests have been added in `blog/tests/views/post_views_test.py` that asserts that unpublished posts are returned from that endpoint.
