### PR TITLE
Features/markdown sanitization

### DIFF
--- a/blog/serializers/post_serializer.py
+++ b/blog/serializers/post_serializer.py
@@ -1,6 +1,6 @@
 from django.utils.text import slugify
 
-from marko import Markdown, Parser
+from marko import Markdown
 from marko.md_renderer import MarkdownRenderer
 
 from rest_framework import serializers

--- a/blog/serializers/post_serializer.py
+++ b/blog/serializers/post_serializer.py
@@ -1,5 +1,8 @@
 from django.utils.text import slugify
 
+from marko import Markdown, Parser
+from marko.md_renderer import MarkdownRenderer
+
 from rest_framework import serializers
 
 from blog.models import Post, Category, User
@@ -61,6 +64,10 @@ class CreatePostSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         self.slug = slugify(data.get("title"))
+
+        if data.get("body") is not None:
+            md_to_md = Markdown(renderer=MarkdownRenderer)
+            self.body = md_to_md(data.get("body"))
 
         super().validate(data)
 

--- a/blog/serializers/project_serializer.py
+++ b/blog/serializers/project_serializer.py
@@ -1,3 +1,6 @@
+from marko import Markdown, Parser
+from marko.md_renderer import MarkdownRenderer
+
 from rest_framework import serializers
 
 from blog.models import Project, User
@@ -47,3 +50,12 @@ class CreateProjectSerializer(serializers.ModelSerializer):
             "url",
             "user",
         ]
+
+    def validate(self, data):
+        if data.get("body") is not None:
+            md_to_md = Markdown(renderer=MarkdownRenderer)
+            self.body = md_to_md(data.get("body"))
+
+        super().validate(data)
+
+        return data

--- a/blog/serializers/project_serializer.py
+++ b/blog/serializers/project_serializer.py
@@ -1,4 +1,4 @@
-from marko import Markdown, Parser
+from marko import Markdown
 from marko.md_renderer import MarkdownRenderer
 
 from rest_framework import serializers

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ Faker==37.4.0
 gunicorn==23.0.0
 idna==3.10
 kombu==5.5.4
+marko==2.2.0
 packaging==25.0
 pillow==11.3.0
 postmarker==1.0


### PR DESCRIPTION
## What?
Adds `Marko` package and uses it to sanitize markdown formatted input on `posts` and `projects` `body` column.

## Why?
users who are unfamiliar with markdown syntax may use incorrect formatting, this makes a small effort to normalize it into proper formatting.

## How?
`Marko` has a `md_to_md` method that normalizes markdown input

## Testing?
N/A, will make test cases if/as issues arise.
