### PR TITLE
Features/prepare production deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 lib/
 lib64*
 pyvenv.cfg
+.*.env
 .env
 __pycache__
 logs/*.log

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,35 @@
+FROM python:3.10-slim AS builder
+
+RUN mkdir /py-api
+
+WORKDIR /py-api
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+RUN pip install --upgrade pip
+
+COPY requirements.txt /py-api/
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+FROM python:3.10-slim
+
+RUN useradd -m -r py-api && \
+        mkdir /py-api && \
+        chown -R py-api /py-api
+
+COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages/
+COPY --from=builder /usr/local/bin/ /usr/local/bin
+
+WORKDIR /py-api
+
+COPY --chown=py-api:py-api . /py-api/
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PATH=$PATH:/home/py-api/.local/bin
+
+EXPOSE 8000
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "3", "py_api.wsgi:application"]

--- a/blog/authentication.py
+++ b/blog/authentication.py
@@ -37,4 +37,4 @@ class CustomAuthentication(JWTAuthentication):
         if not user.confirmed:
             return None
 
-        return self.get_user(validated_token), validated_token
+        return user, validated_token

--- a/blog/tests/views/bookmark_views_test.py
+++ b/blog/tests/views/bookmark_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -11,9 +13,9 @@ from blog.tests.factories import BookmarkFactory, PostFactory, UserFactory
 class AuthenticatedBookmarkTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
         self.post = PostFactory()
 
     def test_authenticated_user_can_list_bookmarks(self):

--- a/blog/tests/views/category_views_test.py
+++ b/blog/tests/views/category_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -101,9 +103,9 @@ class CategoryTests(APITestCase):
 class AuthenticatedCategoryTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
 
     def test_authenticated_user_can_create_category(self):
         response = self.client.post(

--- a/blog/tests/views/comment_views_test.py
+++ b/blog/tests/views/comment_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -11,9 +13,9 @@ from blog.tests.factories import CommentFactory, PostFactory, UserFactory
 class AuthenticatedCommentTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
         self.post = PostFactory()
 
     def test_authenticated_user_can_create_comment(self):

--- a/blog/tests/views/notification_views_test.py
+++ b/blog/tests/views/notification_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -10,9 +12,9 @@ from blog.tests.factories import NotificationFactory, PostFactory, UserFactory
 class AuthenticatedNotificationTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
         self.post = PostFactory(user=self.user)
 
     def test_authenticated_user_can_list_notifications(self):

--- a/blog/tests/views/post_views_test.py
+++ b/blog/tests/views/post_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -11,9 +13,9 @@ from blog.tests.factories import CategoryFactory, PostFactory, UserFactory
 class AuthenticatedPostTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
 
     def test_authenticated_user_can_list_posts(self):
         category = CategoryFactory(user=self.user)

--- a/blog/tests/views/profile_views_test.py
+++ b/blog/tests/views/profile_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -10,9 +12,12 @@ from blog.tests.factories import UserFactory
 class AuthenticatedProfileTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
+        self.user.confirmed = False
+        self.user.confirmed_at = None
+        self.user.save()
 
     def test_authenticated_user_can_retrieve_profile(self):
         profile = self.user.profile

--- a/blog/tests/views/profile_views_test.py
+++ b/blog/tests/views/profile_views_test.py
@@ -15,8 +15,6 @@ class AuthenticatedProfileTests(APITestCase):
         self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
             self.user
         ).access_token
-        self.user.confirmed = False
-        self.user.confirmed_at = None
         self.user.save()
 
     def test_authenticated_user_can_retrieve_profile(self):

--- a/blog/tests/views/project_views_test.py
+++ b/blog/tests/views/project_views_test.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.utils import timezone
 
 from rest_framework import status
@@ -71,9 +72,9 @@ class ProjectTests(APITestCase):
 class AuthenticatedProjectTests(APITestCase):
     def setUp(self):
         self.user = UserFactory()
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
 
     def test_authenticated_user_can_list_projects(self):
         project = ProjectFactory.create(user=self.user)

--- a/blog/tests/views/subscription_views_test.py
+++ b/blog/tests/views/subscription_views_test.py
@@ -223,9 +223,9 @@ class AuthenticatedSubscriptionTests(APITestCase):
     def setUp(self):
         self.user = UserFactory(email="user@example.org")
         self.subscriber = UserFactory(email="subscriber@gmail.com")
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
 
     def test_authenticated_user_can_list_subscriptions(self):
         SubscriptionFactory(user=self.user, email=self.subscriber.email, active=True)

--- a/blog/tests/views/token_views_test.py
+++ b/blog/tests/views/token_views_test.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.utils import timezone
 
 from rest_framework import status
@@ -27,8 +28,7 @@ class BlogTokenObtainPairViewTests(APITestCase):
         response_json = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access_token", response.cookies)
-        self.assertIn("refresh_token", response.cookies)
+        self.assertIn(settings.SIMPLE_JWT["AUTH_COOKIE"], response.cookies)
         self.assertEqual(response_json["message"], "authentication ok")
 
     def test_obtain_token_pair_invalid_credentials(self):
@@ -38,8 +38,7 @@ class BlogTokenObtainPairViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertNotIn("access_token", response.cookies)
-        self.assertNotIn("refresh_token", response.cookies)
+        self.assertNotIn(settings.SIMPLE_JWT["AUTH_COOKIE"], response.cookies)
 
     def test_obtain_token_pair_missing_fields(self):
         response = self.client.post("/user/token", {"email": "testuser@example.com"})
@@ -47,8 +46,7 @@ class BlogTokenObtainPairViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("password", response_json)
-        self.assertNotIn("access_token", response.cookies)
-        self.assertNotIn("refresh_token", response.cookies)
+        self.assertNotIn(settings.SIMPLE_JWT["AUTH_COOKIE"], response.cookies)
 
     def test_obtain_token_pair_invalid_username(self):
         response = self.client.post(
@@ -57,5 +55,4 @@ class BlogTokenObtainPairViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertNotIn("access_token", response.cookies)
-        self.assertNotIn("refresh_token", response.cookies)
+        self.assertNotIn(settings.SIMPLE_JWT["AUTH_COOKIE"], response.cookies)

--- a/blog/tests/views/user_subscription_views_test.py
+++ b/blog/tests/views/user_subscription_views_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.test import APITestCase
@@ -12,9 +14,9 @@ class AuthenticatedUserSubscriptionTests(APITestCase):
     def setUp(self):
         self.user = UserFactory(email="user@example.org")
         self.subscriber = UserFactory(email="subscriber@gmail.com")
-        refresh = RefreshToken.for_user(self.user)
-        access_token = refresh.access_token
-        self.client.cookies["access_token"] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = RefreshToken.for_user(
+            self.user
+        ).access_token
 
     def test_authenticated_user_can_list_subscriptions(self):
         UserSubscription.objects.create(

--- a/blog/views/token_views.py
+++ b/blog/views/token_views.py
@@ -1,4 +1,5 @@
 from django.http import JsonResponse
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_POST
 
@@ -25,14 +26,8 @@ class BlogTokenObtainPairView(TokenObtainPairView):
             {"message": "authentication ok"}, status=status.HTTP_200_OK
         )
         response.set_cookie(
-            key="access_token",
+            key=settings.SIMPLE_JWT["AUTH_COOKIE"],
             value=serializer.validated_data["access"],
-            httponly=True,
-            samesite="Lax",
-        )
-        response.set_cookie(
-            key="refresh_token",
-            value=serializer.validated_data["refresh"],
             httponly=True,
             samesite="Lax",
         )

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,64 @@
+services:
+  py-postgres:
+    image: postgres:17-alpine
+    env_file: .env
+    networks:
+      - dokploy-network
+    ports:
+      - 5433
+    volumes:
+      - py-postgres:/var/lib/postgresql/data
+  py-api:
+    build:
+      context: ./py-api
+      dockerfile: Dockerfile.production
+    depends_on:
+      - py-postgres
+    env_file: .env
+    networks:
+      - dokploy-network
+    ports:
+      - 8000
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.py-api.rule=Host(`api.diegoenriquezserrano.cloud`)"
+      - "traefik.http.routers.py-api.entrypoints=websecure"
+      - "traefik.http.routers.py-api.tls.certResolver=letsencrypt"
+      - "traefik.http.services.py-api.loadbalancer.server.port=8000"
+  py-meilisearch:
+    env_file: .env
+    image: getmeili/meilisearch:v1.15
+    networks:
+      - dokploy-network
+    ports:
+      - 7770
+    volumes:
+      - py-meilisearch:/data.ms
+  py-valkey:
+    command: valkey-server --port ${VALKEY_PORT} --save 60 1 --loglevel ${VALKEY_LOG_LEVEL} --requirepass ${VALKEY_PASSWORD}
+    env_file: .env
+    image: valkey/valkey:8.0-alpine
+    networks:
+      - dokploy-network
+    ports:
+      - 63792
+    volumes:
+      - py-valkey:/data
+  py-cache:
+    command: valkey-server --port ${VALKEY_CACHE_PORT} --save 60 1 --loglevel ${VALKEY_CACHE_LOG_LEVEL} --requirepass ${VALKEY_CACHE_PASSWORD}
+    env_file: .env
+    image: valkey/valkey:8.0-alpine
+    networks:
+      - dokploy-network
+    ports:
+      - 63793
+    volumes:
+      - py-cache:/data
+volumes:
+  py-postgres:
+  py-valkey:
+  py-cache:
+  py-meilisearch:
+networks:
+  dokploy-network:
+    external: true


### PR DESCRIPTION
## What?
- creates `Dockerfile.production` and `docker-compose.production.yml` to create a docker compose based self-hosted deployment to deploy with Dokploy
- gets auth cookie name from settings instead of hard coding
- updates tests accordingly

## Why?
This API has the basic functionality for a multi-tenant blog ready for an initial release. The chosen deployment architecture accepts a docker compose file to create a deployment

## How?
N/A

## Testing?
N/A