### PR TITLE
Fix/get profile on non existing user should return not found

### DIFF
--- a/blog/tests/views/user_views_test.py
+++ b/blog/tests/views/user_views_test.py
@@ -14,3 +14,8 @@ class UserTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response_json["username"], user.username)
+
+    def test_non_existing_user_returns_not_found(self):
+        response = self.client.get("/user/profile/nunya", format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/blog/views/user_views.py
+++ b/blog/views/user_views.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_GET
 
@@ -15,6 +16,6 @@ class ProfileView(generics.RetrieveUpdateAPIView):
 
     def get_object(self):
         username = self.kwargs.get("username")
-        profile = Profile.objects.get(user__username=username)
+        profile = get_object_or_404(Profile, user__username=username)
 
         return profile


### PR DESCRIPTION
## What?
- uses `get_object_or_404` method on the non-authenticated profile by username lookup

## Why?
using the `[Model].get` method raises an error if the object is not found. Returning an error response is acceptable for this request, but it needs to be returned as a 400 level HTTP error for the client API to parse the response successfully (as it is currently configured)

## How?
See `What` section

## Testing?
API test is included to check that a 404 response is returned.